### PR TITLE
CI with maven

### DIFF
--- a/.github/workflows/ci-with-maven.yml
+++ b/.github/workflows/ci-with-maven.yml
@@ -1,0 +1,57 @@
+# This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-maven
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Java CI with Maven
+
+on:
+  pull_request:
+    branches: [ "develop", "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@main
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@main
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Run Tests with Maven
+        run: mvn -B test --file pom.xml
+
+      - uses: actions/cache@main
+        with:
+          path: |
+            target
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Cache SonarCloud packages
+        uses: actions/cache@main
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+
+      - name: Analyze with SonarCloud
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: >
+          mvn -B org.sonarsource.scanner.maven:sonar-maven-plugin:sonar 
+          -Dsonar.projectKey=${{ github.event.repository.name }}
+          -Dsonar.organization=${{ github.repository_owner }}
+          -Dsonar.host.url=https://sonarcloud.io
+          -Dsonar.qualitygate.wait=true

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,12 @@
             <artifactId>spring-boot-starter-webflux</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <version>0.8.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-mongodb-reactive</artifactId>
         </dependency>
@@ -100,6 +106,26 @@
                         </exclude>
                     </excludes>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.12</version>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
## Cambios propuestos
- Crear worflow de GitHub Actions - Java CI con maven
- Agregar plugin de jacoco para el reporte que se pasa a sonarcloud.

## Contexto

Este cambio permite a los desarrolladores compilar, probar y analyzar el proyecto utilizando Maven y Sonar en nuestro flujo de CI.

## Impacto

Esto mejorará la eficiencia del proceso de construcción y garantizará que nuestras reglas de codigo limpio, dependencias y vulnerabilidad se manejen correctamente.

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [x] Completed
- [ ] Not Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

### Configuración de SonarCloud

1. **Obtener el token de SonarCloud**:
   - Ve a [SonarCloud](https://sonarcloud.io/account/security) y genera un nuevo token.
   - Copia el token generado.

2. **Agregar el token como una secret en GitHub**:
   - Ir a la configuración del repositorio en GitHub: https://github.com/EntrevistadorInteligente/orquestador/settings/secrets/actions.
   - Haz clic en "New repository secret".
   - Nombre: `SONAR_TOKEN`.
   - Valor: Pega el token que copiaste anteriormente.
   - Guarda la secret.
