### PR TITLE
Feature/75688055 Integrando Documentación

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,10 @@
         <org.projectlombok.version>1.18.30</org.projectlombok.version>
         <org.projectlombok.mapstruct.binding.version>0.2.0</org.projectlombok.mapstruct.binding.version>
         <mockwebserver.version>4.12.0</mockwebserver.version>
-        <sonar.coverage.exclusions>*/**/jms/**,*/**/beanconfiguration/**,*/**/excepciones/**,*/**/enums/**,*/**/dto/**,*/**/model/**,*/**/properties/**</sonar.coverage.exclusions>
+        <sonar.coverage.exclusions>
+            */**/jms/**,*/**/beanconfiguration/**,*/**/excepciones/**,*/**/enums/**,*/**/dto/**,*/**/model/**,*/**/properties/**
+        </sonar.coverage.exclusions>
+        <springdoc-openapi-starter-webflux-ui.version>2.6.0</springdoc-openapi-starter-webflux-ui.version>
     </properties>
     <dependencies>
         <dependency>
@@ -49,9 +52,8 @@
 
         <!-- https://mvnrepository.com/artifact/javax.validation/validation-api -->
         <dependency>
-            <groupId>javax.validation</groupId>
-            <artifactId>validation-api</artifactId>
-            <version>2.0.1.Final</version>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.owasp.encoder/encoder -->
         <dependency>
@@ -63,6 +65,12 @@
             <groupId>org.mapstruct</groupId>
             <artifactId>mapstruct</artifactId>
             <version>${org.mapstruct.version}</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/org.springdoc/springdoc-openapi-starter-webflux-ui -->
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webflux-ui</artifactId>
+            <version>${springdoc-openapi-starter-webflux-ui.version}</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/com/entrevistador/orquestador/OrquestadorApplication.java
+++ b/src/main/java/com/entrevistador/orquestador/OrquestadorApplication.java
@@ -2,6 +2,7 @@ package com.entrevistador.orquestador;
 
 import com.entrevistador.orquestador.infrastructure.properties.EntrevistaPruebaConst;
 import com.entrevistador.orquestador.infrastructure.properties.WebFluxProperties;
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -10,6 +11,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @SpringBootApplication
 @EnableConfigurationProperties({EntrevistaPruebaConst.class, WebFluxProperties.class})
 @EnableScheduling
+@OpenAPIDefinition
 public class OrquestadorApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/entrevistador/orquestador/infrastructure/adapter/dto/FormularioDto.java
+++ b/src/main/java/com/entrevistador/orquestador/infrastructure/adapter/dto/FormularioDto.java
@@ -2,13 +2,12 @@ package com.entrevistador.orquestador.infrastructure.adapter.dto;
 
 
 import com.entrevistador.orquestador.infrastructure.adapter.constants.ValidationsMessagesData;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-
-import javax.validation.constraints.NotNull;
 
 @Getter
 @Setter

--- a/src/main/java/com/entrevistador/orquestador/infrastructure/adapter/dto/PerfilDto.java
+++ b/src/main/java/com/entrevistador/orquestador/infrastructure/adapter/dto/PerfilDto.java
@@ -2,13 +2,13 @@ package com.entrevistador.orquestador.infrastructure.adapter.dto;
 
 import com.entrevistador.orquestador.infrastructure.adapter.constants.ValidationsMessagesData;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Pattern;
 import java.time.LocalDateTime;
 import java.util.List;
 

--- a/src/main/java/com/entrevistador/orquestador/infrastructure/rest/controller/EntrevistaController.java
+++ b/src/main/java/com/entrevistador/orquestador/infrastructure/rest/controller/EntrevistaController.java
@@ -23,8 +23,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Mono;
 
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 
 
 @RestController

--- a/src/main/java/com/entrevistador/orquestador/infrastructure/rest/controller/HojaDeVidaController.java
+++ b/src/main/java/com/entrevistador/orquestador/infrastructure/rest/controller/HojaDeVidaController.java
@@ -21,8 +21,8 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Mono;
 
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 
 @RestController
 @RequestMapping("/v1/hojas-de-vidas")

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -25,3 +25,6 @@ mongo.database.connection-string=mongodb+srv://${MONGO_ATLAS_USER}:${MONGO_ATLAS
 logging.level.org.springframework.data.mongodb.core.MongoTemplate= DEBUG
 
 spring.config.import=classpath:/variables-constantes.yml
+
+springdoc.api-docs.path=/api-docs
+springdoc.swagger-ui.operationsSorter=method


### PR DESCRIPTION
- Agregando dependencia springdoc openapi starter webflux ui
- Remplazando dependencia validation-api javax por spring validation jakarta que incluye JSR-303 y sea compatible con open api
- Modificando importes en Dto y Controller

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple PRs instead of opening a huge one.
-->

## 📑 Description
<!-- Add a brief description of the pr -->
Se integra documentación mediante SpringDoc OpenApi

Ingresar mediante la URL: /api/orquestador/swagger-ui.html
Input: /api/orquestador/api-docs

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [x] Completed
- [ ] Not Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
